### PR TITLE
Add LCS variations support

### DIFF
--- a/knapsack_react_flask/backend/app.py
+++ b/knapsack_react_flask/backend/app.py
@@ -11,12 +11,24 @@ INSIGHTS = {
     "unbounded": "Similar to 0/1 but allows multiple use of the same item at each step.",
     "fractional": "Sort by value/weight ratio and take portions greedily.",
     "subset_sum": "Boolean DP where dp[i][t] tells if sum t is possible with first i numbers.",
-    "subset_partition": "Check subset sum for half of total array sum to see if partition exists."
+    "subset_partition": "Check subset sum for half of total array sum to see if partition exists.",
+    "lcs": "Classic LCS DP where dp[i][j] stores length of LCS for prefixes.",
+    "lcsubstring": "Track consecutive matches for longest common substring.",
+    "scs": "Build DP for shortest common supersequence length and reconstruction."
 }
 
 
 def generate_problem(level="medium", ptype="01"):
     """Generate random problem parameters adjusted for the knapsack variant."""
+
+    if ptype in ["lcs", "lcsubstring", "scs"]:
+        length_map = {"easy": 4, "medium": 6, "hard": 8}
+        m = length_map[level]
+        n = length_map[level]
+        alphabet = "abcdef"
+        s1 = "".join(random.choice(alphabet) for _ in range(m))
+        s2 = "".join(random.choice(alphabet) for _ in range(n))
+        return s1, s2, m, n
 
     if ptype in ["subset_sum", "subset_partition"]:
         n = {"easy": 4, "medium": 5, "hard": 6}[level]
@@ -129,11 +141,98 @@ def traceback_knapsack(dp, values, weights, W):
     return items[::-1]
 
 
+def solve_lcs(s1, s2):
+    m, n = len(s1), len(s2)
+    dp = [[0] * (n + 1) for _ in range(m + 1)]
+    for i in range(1, m + 1):
+        for j in range(1, n + 1):
+            if s1[i - 1] == s2[j - 1]:
+                dp[i][j] = dp[i - 1][j - 1] + 1
+            else:
+                dp[i][j] = max(dp[i - 1][j], dp[i][j - 1])
+    return dp
+
+
+def traceback_lcs(dp, s1, s2):
+    i, j = len(s1), len(s2)
+    seq = []
+    while i > 0 and j > 0:
+        if s1[i - 1] == s2[j - 1]:
+            seq.append(s1[i - 1])
+            i -= 1
+            j -= 1
+        elif dp[i - 1][j] >= dp[i][j - 1]:
+            i -= 1
+        else:
+            j -= 1
+    return "".join(reversed(seq))
+
+
+def solve_longest_common_substring(s1, s2):
+    m, n = len(s1), len(s2)
+    dp = [[0] * (n + 1) for _ in range(m + 1)]
+    max_len = 0
+    end_idx = 0
+    for i in range(1, m + 1):
+        for j in range(1, n + 1):
+            if s1[i - 1] == s2[j - 1]:
+                dp[i][j] = dp[i - 1][j - 1] + 1
+                if dp[i][j] > max_len:
+                    max_len = dp[i][j]
+                    end_idx = i
+            else:
+                dp[i][j] = 0
+    substr = s1[end_idx - max_len:end_idx]
+    return dp, substr
+
+
+def solve_scs(s1, s2):
+    m, n = len(s1), len(s2)
+    dp = [[0] * (n + 1) for _ in range(m + 1)]
+    for i in range(m + 1):
+        dp[i][0] = i
+    for j in range(n + 1):
+        dp[0][j] = j
+    for i in range(1, m + 1):
+        for j in range(1, n + 1):
+            if s1[i - 1] == s2[j - 1]:
+                dp[i][j] = dp[i - 1][j - 1] + 1
+            else:
+                dp[i][j] = min(dp[i - 1][j], dp[i][j - 1]) + 1
+    return dp
+
+
+def traceback_scs(dp, s1, s2):
+    i, j = len(s1), len(s2)
+    res = []
+    while i > 0 and j > 0:
+        if s1[i - 1] == s2[j - 1]:
+            res.append(s1[i - 1])
+            i -= 1
+            j -= 1
+        elif dp[i - 1][j] < dp[i][j - 1]:
+            res.append(s1[i - 1])
+            i -= 1
+        else:
+            res.append(s2[j - 1])
+            j -= 1
+    while i > 0:
+        res.append(s1[i - 1])
+        i -= 1
+    while j > 0:
+        res.append(s2[j - 1])
+        j -= 1
+    return "".join(reversed(res))
+
+
 @app.route("/generate", methods=["POST"])
 def generate():
     data = request.get_json()
     level = data.get("level", "medium")
     ptype = data.get("type", "01")
+    if ptype in ["lcs", "lcsubstring", "scs"]:
+        s1, s2, m, n = generate_problem(level, ptype)
+        return jsonify({"s1": s1, "s2": s2, "m": m, "n": n})
     values, weights, W, n = generate_problem(level, ptype)
     return jsonify({"values": values, "weights": weights, "W": W, "n": n})
 
@@ -141,10 +240,25 @@ def generate():
 @app.route("/solve", methods=["POST"])
 def solve():
     data = request.get_json()
+    knap_type = data.get("type", "01")
+    if knap_type in ["lcs", "lcsubstring", "scs"]:
+        s1 = data["s1"]
+        s2 = data["s2"]
+        if knap_type == "lcs":
+            dp = solve_lcs(s1, s2)
+            seq = traceback_lcs(dp, s1, s2)
+            return jsonify({"dp": dp, "result": seq, "insight": INSIGHTS["lcs"]})
+        elif knap_type == "lcsubstring":
+            dp, substr = solve_longest_common_substring(s1, s2)
+            return jsonify({"dp": dp, "result": substr, "insight": INSIGHTS["lcsubstring"]})
+        else:
+            dp = solve_scs(s1, s2)
+            seq = traceback_scs(dp, s1, s2)
+            return jsonify({"dp": dp, "result": seq, "insight": INSIGHTS["scs"]})
+
     values = data["values"]
     weights = data["weights"]
     W = data["W"]
-    knap_type = data.get("type", "01")
     if knap_type == "unbounded":
         dp = solve_unbounded_knapsack(values, weights, W)
         return jsonify({"dp": dp, "insight": INSIGHTS["unbounded"]})

--- a/knapsack_react_flask/frontend/src/App.css
+++ b/knapsack_react_flask/frontend/src/App.css
@@ -1,9 +1,10 @@
 
 body {
   font-family: Roboto, sans-serif;
-  padding: 20px;
+  margin: 0;
+  background-color: #f5f5f5;
 }
 
-#export {
-  padding: 10px;
+.App {
+  margin-top: 20px;
 }

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -6,6 +6,9 @@ from knapsack_react_flask.backend.app import (
     solve_unbounded_knapsack,
     solve_fractional_knapsack,
     solve_subset_sum,
+    solve_lcs,
+    solve_longest_common_substring,
+    solve_scs,
 )
 
 def test_solve_knapsack():
@@ -34,3 +37,24 @@ def test_solve_subset_sum():
     W = 9
     dp = solve_subset_sum(values, W)
     assert dp[-1][W] is True
+
+
+def test_solve_lcs():
+    s1 = "abcde"
+    s2 = "ace"
+    dp = solve_lcs(s1, s2)
+    assert dp[-1][-1] == 3
+
+
+def test_longest_common_substring():
+    s1 = "abcdxyz"
+    s2 = "xyzabcd"
+    dp, substr = solve_longest_common_substring(s1, s2)
+    assert substr == "abcd"
+
+
+def test_scs():
+    s1 = "abac"
+    s2 = "cab"
+    dp = solve_scs(s1, s2)
+    assert dp[-1][-1] == 5


### PR DESCRIPTION
## Summary
- support LCS, longest common substring and SCS problems
- add ability to generate/solve LCS problems in the Flask backend
- extend React frontend to use new variations
- cover new solvers with tests
- modernize React layout with Material UI AppBar and Paper

## Testing
- `pip install -r knapsack_react_flask/backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685671119aac832ca906fed471db266e