### PR TITLE
[feature] Add step-by-step DP table visualization

### DIFF
--- a/knapsack_react_flask/frontend/src/DPTableVisualizer.jsx
+++ b/knapsack_react_flask/frontend/src/DPTableVisualizer.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from '@mui/material';
+
+function DPTableVisualizer({ dp, category, problem, highlight }) {
+  return (
+    <TableContainer component={Paper}>
+      <Table size="small" sx={{ '& td, & th': { border: 1, padding: '4px', textAlign: 'center' } }}>
+        <TableHead>
+          <TableRow>
+            <TableCell>{category === 'lcs' ? 'i\\j' : 'i\\w'}</TableCell>
+            {category === 'lcs' && problem.n && [...Array(problem.n + 1).keys()].map(c => (
+              <TableCell key={c}>{c}</TableCell>
+            ))}
+            {category !== 'lcs' && problem.W && [...Array(problem.W + 1).keys()].map(w => (
+              <TableCell key={w}>{w}</TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {dp.map((row, i) => (
+            <TableRow key={i}>
+              <TableCell>{i}</TableCell>
+              {row.map((cell, j) => (
+                <TableCell key={j} className={highlight.has(`${i}-${j}`) ? 'path-cell' : ''}>
+                  {cell}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+export default DPTableVisualizer;

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -9,6 +9,7 @@ from knapsack_react_flask.backend.app import (
     solve_lcs,
     solve_longest_common_substring,
     solve_scs,
+    solve_knapsack_steps
 )
 
 def test_solve_knapsack():
@@ -58,3 +59,13 @@ def test_scs():
     s2 = "cab"
     dp = solve_scs(s1, s2)
     assert dp[-1][-1] == 5
+
+
+def test_solve_knapsack_steps():
+    values = [1, 2, 3]
+    weights = [1, 2, 3]
+    W = 5
+    dp, steps = solve_knapsack_steps(values, weights, W)
+    assert dp[-1][-1] == 5
+    assert len(steps) == len(values) * (W + 1)
+    assert steps[-1][-1][-1] == 5


### PR DESCRIPTION
## Summary
- add solve_knapsack_steps to return DP state after each cell update
- expose `/solve_steps` endpoint in Flask backend
- add DPTableVisualizer React component
- integrate step mode toggle with prev/next controls in App
- test new solver function

## Testing
- `cd knapsack_react_flask/backend && pytest ../../tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6857ba01d0e4832c9248783056217091