### PR TITLE
Add step mode coords and version display

### DIFF
--- a/knapsack_react_flask/frontend/src/version.js
+++ b/knapsack_react_flask/frontend/src/version.js
@@ -1,0 +1,2 @@
+export const VERSION = '1.0.1';
+export const TIMESTAMP_IST = '2025-06-22 15:14:06 IST';

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -65,7 +65,8 @@ def test_solve_knapsack_steps():
     values = [1, 2, 3]
     weights = [1, 2, 3]
     W = 5
-    dp, steps = solve_knapsack_steps(values, weights, W)
+    dp, steps, coords = solve_knapsack_steps(values, weights, W)
     assert dp[-1][-1] == 5
     assert len(steps) == len(values) * (W + 1)
+    assert len(coords) == len(steps)
     assert steps[-1][-1][-1] == 5


### PR DESCRIPTION
## Summary
- extend step-mode solvers to return coordinates
- update `/solve_steps` API to include `coords`
- color visited cells in frontend even when values don't change
- handle unsupported step mode errors
- show version number with timestamp in the UI
- include problem variation in PDF export

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857cf9524b8832c899a70c8012ea9d4