### PR TITLE
[frontend] Darken DP table grid lines

### DIFF
--- a/knapsack_react_flask/frontend/src/DPTableVisualizer.jsx
+++ b/knapsack_react_flask/frontend/src/DPTableVisualizer.jsx
@@ -4,7 +4,10 @@ import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper
 function DPTableVisualizer({ dp, category, problem, highlight, changed, filled }) {
   return (
     <TableContainer component={Paper} className="dp-table">
-      <Table size="small" sx={{ '& td, & th': { border: 1, padding: '4px', textAlign: 'center' } }}>
+      <Table
+        size="small"
+        sx={{ '& td, & th': { border: 1, borderColor: '#000', padding: '4px', textAlign: 'center' } }}
+      >
         <TableHead>
           <TableRow>
             <TableCell>{category === 'lcs' ? 'i\\j' : 'i\\w'}</TableCell>


### PR DESCRIPTION
## Summary
- force MUI table borders to render in black

## Testing
- `cd knapsack_react_flask/backend && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685811d31378832cba70f260c0e42487